### PR TITLE
Fix concurrent ingest upsert and add regression test

### DIFF
--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -7,12 +7,39 @@
     "": {
       "name": "api",
       "version": "1.0.0",
-      "license": "ISC",
+      "license": "MIT",
       "dependencies": {
         "cors": "^2.8.5",
         "dotenv": "^17.2.2",
         "express": "^5.1.0",
         "pg": "^8.16.3"
+      },
+      "devDependencies": {
+        "pg-mem": "^3.0.5",
+        "supertest": "^7.1.1"
+      }
+    },
+    "node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@paralleldrive/cuid2": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/@paralleldrive/cuid2/-/cuid2-2.2.2.tgz",
+      "integrity": "sha512-ZOBkgDwEdoYVlSeRbYYXs0S9MejQofiVYoTbKzy/6GQa39/q5tQU2IX46+shYnUkpEl3wc+J6wRlar7r2EK2xA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "^1.1.5"
       }
     },
     "node_modules/accepts": {
@@ -27,6 +54,20 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/asap": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+      "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/body-parser": {
       "version": "2.2.0",
@@ -57,6 +98,25 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/call-bind": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
+      "integrity": "sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.0",
+        "es-define-property": "^1.0.0",
+        "get-intrinsic": "^1.2.4",
+        "set-function-length": "^1.2.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/call-bind-apply-helpers": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
@@ -84,6 +144,36 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/component-emitter": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.1.tgz",
+      "integrity": "sha512-T0+barUSQRTUQASh8bx02dl+DhF54GtIDY13Y3m9oWTklKbb3Wv974meRpeZ3lp1JpLVECWWNHC4vaG2XHXouQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/content-disposition": {
@@ -125,6 +215,13 @@
         "node": ">=6.6.0"
       }
     },
+    "node_modules/cookiejar": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.4.tgz",
+      "integrity": "sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/cors": {
       "version": "2.8.5",
       "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
@@ -155,6 +252,34 @@
         }
       }
     },
+    "node_modules/define-data-property": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
+      "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/depd": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
@@ -163,6 +288,24 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/dezalgo": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.4.tgz",
+      "integrity": "sha512-rXSP0bf+5n0Qonsb+SVVfNfIsimO4HEtmnIpPHY8Q1UCzKlQrDMfdobr8nJOOsRgWCyMRqeSBQzmWUMq7zvVig==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "asap": "^2.0.0",
+        "wrappy": "1"
+      }
+    },
+    "node_modules/discontinuous-range": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/discontinuous-range/-/discontinuous-range-1.0.0.tgz",
+      "integrity": "sha512-c68LpLbO+7kP/b1Hr1qs8/BJ09F5khZGTxqxZuhzxpmwJKOgRFHJWIb9/KmqnqHhLdO55aOxFH/EGBvUQbL/RQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/dotenv": {
       "version": "17.2.2",
@@ -235,6 +378,22 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/escape-html": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
@@ -292,6 +451,13 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/fast-safe-stringify": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
+      "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/finalhandler": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.0.tgz",
@@ -307,6 +473,64 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
+      "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/form-data/node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/form-data/node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/formidable": {
+      "version": "3.5.4",
+      "resolved": "https://registry.npmjs.org/formidable/-/formidable-3.5.4.tgz",
+      "integrity": "sha512-YikH+7CUTOtP44ZTnUhR7Ic2UASBPOqmaRkRKxRbywPTe5VxF7RRCck4af9wutiZ/QKM5nME9Bie2fFaPz5Gug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@paralleldrive/cuid2": "^2.2.2",
+        "dezalgo": "^1.0.4",
+        "once": "^1.4.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "url": "https://ko-fi.com/tunnckoCore/commissions"
       }
     },
     "node_modules/forwarded": {
@@ -335,6 +559,13 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/functional-red-black-tree": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
+      "integrity": "sha512-dsKNQNdj6xA3T+QlADDA7mOSlX0qiMINjn0cgr+eGHGsbSHzTabcIogz2+p/iqP1Xs6EP/sS2SbqH+brGTbq0g==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/get-intrinsic": {
       "version": "1.3.0",
@@ -385,11 +616,40 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/has-property-descriptors": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+      "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/has-symbols": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
       "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
       "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
       "engines": {
         "node": ">= 0.4"
       },
@@ -446,6 +706,13 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/immutable": {
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.3.7.tgz",
+      "integrity": "sha512-1hqclzwYwjRDFLjcFxOM5AYkkG0rpFPpr1RLPMEuGczoS7YA8gLhy8SWXYRAA/XwfEHpfo3cw5JGioS32fnMRw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
@@ -466,6 +733,56 @@
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
       "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
       "license": "MIT"
+    },
+    "node_modules/isarray": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-stable-stringify": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.3.0.tgz",
+      "integrity": "sha512-qtYiSSFlwot9XHtF9bD9c7rwKjr+RecWT//ZnPvSmEjpV5mmPOCN4j8UjY5hbjNkOwZ/jQv3J6R1/pL7RwgMsg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "isarray": "^2.0.5",
+        "jsonify": "^0.0.1",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/jsonify": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.1.tgz",
+      "integrity": "sha512-2/Ki0GcmuqSrgFyelQq9M05y7PS0mEwuIzrf3f1fPqkVDVRvZrPZtVSMHxdgo8Aq0sxAOb/cr2aqqA3LeWHVPg==",
+      "dev": true,
+      "license": "Public Domain",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
@@ -497,6 +814,29 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/methods": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+      "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
+      "integrity": "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
     "node_modules/mime-db": {
       "version": "1.54.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
@@ -518,11 +858,51 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/moment": {
+      "version": "2.30.1",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
+      "integrity": "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/moo": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/moo/-/moo-0.5.2.tgz",
+      "integrity": "sha512-iSAJLHYKnX41mKcJKjqvnAN9sf0LMDTXDEvFv+ffuRR9a1MIuXLjMNL6EsnDHSkKLTWNqQQ5uo61P4EbU4NU+Q==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
+    },
+    "node_modules/nearley": {
+      "version": "2.20.1",
+      "resolved": "https://registry.npmjs.org/nearley/-/nearley-2.20.1.tgz",
+      "integrity": "sha512-+Mc8UaAebFzgV+KpI5n7DasuuQCHA89dmwm7JXw3TV43ukfNQ9DnBH3Mdb2g/I4Fdxc26pwimBWvjIw0UAILSQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "commander": "^2.19.0",
+        "moo": "^0.5.0",
+        "railroad-diagrams": "^1.0.0",
+        "randexp": "0.4.6"
+      },
+      "bin": {
+        "nearley-railroad": "bin/nearley-railroad.js",
+        "nearley-test": "bin/nearley-test.js",
+        "nearley-unparse": "bin/nearley-unparse.js",
+        "nearleyc": "bin/nearleyc.js"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://nearley.js.org/#give-to-nearley"
+      }
     },
     "node_modules/negotiator": {
       "version": "1.0.0",
@@ -542,6 +922,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/object-hash": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-2.2.0.tgz",
+      "integrity": "sha512-gScRMn0bS5fH+IuwyIFgnh9zBdo4DV+6GhygmWM9HyNJSgS0hScp1f5vjtm7oIIOiT9trXrShAkLFSc2IqKNgw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/object-inspect": {
       "version": "1.13.4",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
@@ -552,6 +942,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/object-keys": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/on-finished": {
@@ -643,6 +1043,65 @@
         "node": ">=4.0.0"
       }
     },
+    "node_modules/pg-mem": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/pg-mem/-/pg-mem-3.0.5.tgz",
+      "integrity": "sha512-Bh8xHD6u/wUXCoyFE2vyRs5pgaKbqjWFQowKDlbKWCiF0vOlo2A0PZdiUxmf2PKgb6Vb6C7gwAlA7jKvsfDHZA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "functional-red-black-tree": "^1.0.1",
+        "immutable": "^4.3.4",
+        "json-stable-stringify": "^1.0.1",
+        "lru-cache": "^6.0.0",
+        "moment": "^2.27.0",
+        "object-hash": "^2.0.3",
+        "pgsql-ast-parser": "^12.0.1"
+      },
+      "peerDependencies": {
+        "@mikro-orm/core": ">=4.5.3",
+        "@mikro-orm/postgresql": ">=4.5.3",
+        "knex": ">=0.20",
+        "kysely": ">=0.26",
+        "pg-promise": ">=10.8.7",
+        "pg-server": "^0.1.5",
+        "postgres": "^3.4.4",
+        "slonik": ">=23.0.1",
+        "typeorm": ">=0.2.29"
+      },
+      "peerDependenciesMeta": {
+        "@mikro-orm/core": {
+          "optional": true
+        },
+        "@mikro-orm/postgresql": {
+          "optional": true
+        },
+        "knex": {
+          "optional": true
+        },
+        "kysely": {
+          "optional": true
+        },
+        "mikro-orm": {
+          "optional": true
+        },
+        "pg-promise": {
+          "optional": true
+        },
+        "pg-server": {
+          "optional": true
+        },
+        "postgres": {
+          "optional": true
+        },
+        "slonik": {
+          "optional": true
+        },
+        "typeorm": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/pg-pool": {
       "version": "3.10.1",
       "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.10.1.tgz",
@@ -681,6 +1140,17 @@
       "license": "MIT",
       "dependencies": {
         "split2": "^4.1.0"
+      }
+    },
+    "node_modules/pgsql-ast-parser": {
+      "version": "12.0.1",
+      "resolved": "https://registry.npmjs.org/pgsql-ast-parser/-/pgsql-ast-parser-12.0.1.tgz",
+      "integrity": "sha512-pe8C6Zh5MsS+o38WlSu18NhrTjAv1UNMeDTs2/Km2ZReZdYBYtwtbWGZKK2BM2izv5CrQpbmP0oI10wvHOwv4A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "moo": "^0.5.1",
+        "nearley": "^2.19.5"
       }
     },
     "node_modules/postgres-array": {
@@ -750,6 +1220,27 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/railroad-diagrams": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/railroad-diagrams/-/railroad-diagrams-1.0.0.tgz",
+      "integrity": "sha512-cz93DjNeLY0idrCNOH6PviZGRN9GJhsdm9hpn1YCS879fj4W+x5IFJhhkRZcwVgMmFF7R82UA/7Oh+R8lLZg6A==",
+      "dev": true,
+      "license": "CC0-1.0"
+    },
+    "node_modules/randexp": {
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/randexp/-/randexp-0.4.6.tgz",
+      "integrity": "sha512-80WNmd9DA0tmZrw9qQa62GPPWfuXJknrmVmLcxvq4uZBdYqb1wYoKTmnlGUchvVWe0XiLupYkBoXVOxz3C8DYQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "discontinuous-range": "1.0.0",
+        "ret": "~0.1.10"
+      },
+      "engines": {
+        "node": ">=0.12"
+      }
+    },
     "node_modules/range-parser": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
@@ -788,6 +1279,16 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/ret": {
+      "version": "0.1.15",
+      "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
+      "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12"
       }
     },
     "node_modules/router": {
@@ -867,6 +1368,24 @@
       },
       "engines": {
         "node": ">= 18"
+      }
+    },
+    "node_modules/set-function-length": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
+      "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.1.4",
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2",
+        "get-intrinsic": "^1.2.4",
+        "gopd": "^1.0.1",
+        "has-property-descriptors": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/setprototypeof": {
@@ -965,6 +1484,41 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/superagent": {
+      "version": "10.2.3",
+      "resolved": "https://registry.npmjs.org/superagent/-/superagent-10.2.3.tgz",
+      "integrity": "sha512-y/hkYGeXAj7wUMjxRbB21g/l6aAEituGXM9Rwl4o20+SX3e8YOSV6BxFXl+dL3Uk0mjSL3kCbNkwURm8/gEDig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "component-emitter": "^1.3.1",
+        "cookiejar": "^2.1.4",
+        "debug": "^4.3.7",
+        "fast-safe-stringify": "^2.1.1",
+        "form-data": "^4.0.4",
+        "formidable": "^3.5.4",
+        "methods": "^1.1.2",
+        "mime": "2.6.0",
+        "qs": "^6.11.2"
+      },
+      "engines": {
+        "node": ">=14.18.0"
+      }
+    },
+    "node_modules/supertest": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/supertest/-/supertest-7.1.4.tgz",
+      "integrity": "sha512-tjLPs7dVyqgItVFirHYqe2T+MfWc2VOBQ8QFKKbWTA3PU7liZR8zoSpAi/C1k1ilm9RsXIKYf197oap9wXGVYg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "methods": "^1.1.2",
+        "superagent": "^10.2.3"
+      },
+      "engines": {
+        "node": ">=14.18.0"
+      }
+    },
     "node_modules/toidentifier": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
@@ -1020,6 +1574,13 @@
       "engines": {
         "node": ">=0.4"
       }
+    },
+    "node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true,
+      "license": "ISC"
     }
   }
 }

--- a/api/package.json
+++ b/api/package.json
@@ -6,7 +6,8 @@
   "main": "src/server.js",
   "scripts": {
     "start": "node src/server.js",
-    "dev": "node --watch src/server.js"
+    "dev": "node --watch src/server.js",
+    "test": "node --test"
   },
   "keywords": ["crm", "express"],
   "author": "",
@@ -16,5 +17,9 @@
     "dotenv": "^17.2.2",
     "express": "^5.1.0",
     "pg": "^8.16.3"
+  },
+  "devDependencies": {
+    "pg-mem": "^3.0.5",
+    "supertest": "^7.1.1"
   }
 }

--- a/api/src/app.js
+++ b/api/src/app.js
@@ -1,0 +1,143 @@
+import express from 'express';
+import cors from 'cors';
+
+function normalizeTitle(subject) {
+  const cleaned = (subject || 'Untitled')
+    .replace(/\[J:\d+\]/g, '')
+    .replace(/\s+/g, ' ')
+    .trim();
+  return cleaned || 'Untitled';
+}
+
+export function createApp({ pool, apiKey } = {}) {
+  if (!pool) {
+    throw new Error('A PostgreSQL pool is required to create the app.');
+  }
+
+  const app = express();
+  app.use(cors());
+  app.use(express.json({ limit: '1mb' }));
+
+  const key = apiKey || 'change_me_secret_key';
+  app.use((req, res, next) => {
+    if (req.headers['x-api-key'] !== key) {
+      return res.status(401).json({ error: 'Unauthorized' });
+    }
+    return next();
+  });
+
+  app.get('/health', (req, res) => res.json({ ok: true }));
+
+  app.get('/jobs', async (req, res, next) => {
+    try {
+      const { status } = req.query;
+      const params = [];
+      const where = status ? (params.push(status), 'WHERE status = $1') : '';
+      const { rows } = await pool.query(
+        `SELECT * FROM jobs ${where} ORDER BY created_at DESC LIMIT 200`,
+        params,
+      );
+      res.json(rows);
+    } catch (err) {
+      next(err);
+    }
+  });
+
+  app.post('/jobs', async (req, res, next) => {
+    try {
+      const {
+        job_no,
+        title,
+        status = 'intake',
+        in_hands_date,
+        owner,
+        priority,
+        est_so_no,
+      } = req.body || {};
+      if (!job_no || !title) {
+        return res.status(400).json({ error: 'job_no and title required' });
+      }
+      const query = `INSERT INTO jobs (job_no,title,status,in_hands_date,owner,priority,est_so_no)
+               VALUES ($1,$2,$3,$4,$5,$6,$7) RETURNING *`;
+      const values = [
+        job_no,
+        title,
+        status,
+        in_hands_date || null,
+        owner || null,
+        priority || null,
+        est_so_no || null,
+      ];
+      const { rows } = await pool.query(query, values);
+      res.json(rows[0]);
+    } catch (err) {
+      next(err);
+    }
+  });
+
+  app.post('/activities/ingest', async (req, res, next) => {
+    try {
+      const { job_no, subject, snippet, gmail_link, source = 'email' } = req.body || {};
+      if (!job_no) {
+        return res.status(400).json({ error: 'job_no required' });
+      }
+
+      const jobTitle = normalizeTitle(subject);
+      const jobResult = await pool.query(
+        `INSERT INTO jobs (job_no, title, status)
+         VALUES ($1, $2, $3)
+         ON CONFLICT (job_no)
+         DO UPDATE SET title = jobs.title
+         RETURNING id`,
+        [job_no, jobTitle, 'intake'],
+      );
+      const jobId = jobResult.rows[0].id;
+
+      const activity = await pool.query(
+        'INSERT INTO activities (job_id,source,snippet,gmail_link) VALUES ($1,$2,$3,$4) RETURNING *',
+        [jobId, source, snippet || null, gmail_link || null],
+      );
+      res.json({ ok: true, activity: activity.rows[0] });
+    } catch (err) {
+      next(err);
+    }
+  });
+
+  app.patch('/jobs/:id', async (req, res, next) => {
+    try {
+      const { id } = req.params;
+      const { status, in_hands_date } = req.body || {};
+      const sets = [];
+      const values = [];
+      let i = 1;
+      if (status) {
+        sets.push(`status=$${i++}`);
+        values.push(status);
+      }
+      if (in_hands_date) {
+        sets.push(`in_hands_date=$${i++}`);
+        values.push(in_hands_date);
+      }
+      if (!sets.length) {
+        return res.status(400).json({ error: 'no changes' });
+      }
+      values.push(id);
+      const { rows } = await pool.query(
+        `UPDATE jobs SET ${sets.join(', ')} WHERE id=$${i} RETURNING *`,
+        values,
+      );
+      res.json(rows[0]);
+    } catch (err) {
+      next(err);
+    }
+  });
+
+  app.use((err, req, res, next) => {
+    console.error(err);
+    res.status(500).json({ error: 'Internal Server Error' });
+  });
+
+  return app;
+}
+
+export default createApp;

--- a/api/src/server.js
+++ b/api/src/server.js
@@ -1,23 +1,10 @@
-import express from 'express';
-import cors from 'cors';
 import dotenv from 'dotenv';
 import pkg from 'pg';
+import { createApp } from './app.js';
 
 const { Pool } = pkg;
 
 dotenv.config();
-
-const app = express();
-app.use(cors());
-app.use(express.json({ limit: '1mb' }));
-
-const API_KEY = process.env.API_KEY || 'change_me_secret_key';
-app.use((req, res, next) => {
-  if (req.headers['x-api-key'] !== API_KEY) {
-    return res.status(401).json({ error: 'Unauthorized' });
-  }
-  return next();
-});
 
 const pool = new Pool({
   host: process.env.PGHOST,
@@ -27,112 +14,9 @@ const pool = new Pool({
   password: process.env.PGPASSWORD,
 });
 
-app.get('/health', (req, res) => res.json({ ok: true }));
-
-app.get('/jobs', async (req, res, next) => {
-  try {
-    const { status } = req.query;
-    const params = [];
-    const where = status ? (params.push(status), 'WHERE status = $1') : '';
-    const { rows } = await pool.query(
-      `SELECT * FROM jobs ${where} ORDER BY created_at DESC LIMIT 200`,
-      params,
-    );
-    res.json(rows);
-  } catch (err) {
-    next(err);
-  }
-});
-
-app.post('/jobs', async (req, res, next) => {
-  try {
-    const {
-      job_no,
-      title,
-      status = 'intake',
-      in_hands_date,
-      owner,
-      priority,
-      est_so_no,
-    } = req.body || {};
-    if (!job_no || !title) {
-      return res.status(400).json({ error: 'job_no and title required' });
-    }
-    const query = `INSERT INTO jobs (job_no,title,status,in_hands_date,owner,priority,est_so_no)
-             VALUES ($1,$2,$3,$4,$5,$6,$7) RETURNING *`;
-    const values = [
-      job_no,
-      title,
-      status,
-      in_hands_date || null,
-      owner || null,
-      priority || null,
-      est_so_no || null,
-    ];
-    const { rows } = await pool.query(query, values);
-    res.json(rows[0]);
-  } catch (err) {
-    next(err);
-  }
-});
-
-app.post('/activities/ingest', async (req, res, next) => {
-  try {
-    const { job_no, subject, snippet, gmail_link, source = 'email' } = req.body || {};
-    if (!job_no) {
-      return res.status(400).json({ error: 'job_no required' });
-    }
-    const found = await pool.query('SELECT id FROM jobs WHERE job_no=$1 LIMIT 1', [job_no]);
-    const jobId = found.rowCount
-      ? found.rows[0].id
-      : (
-          await pool.query(
-            'INSERT INTO jobs (job_no,title,status) VALUES ($1,$2,$3) RETURNING id',
-            [job_no, (subject || 'Untitled').replace(/\[J:\d+\]/g, '').trim(), 'intake'],
-          )
-        ).rows[0].id;
-    const activity = await pool.query(
-      'INSERT INTO activities (job_id,source,snippet,gmail_link) VALUES ($1,$2,$3,$4) RETURNING *',
-      [jobId, source, snippet || null, gmail_link || null],
-    );
-    res.json({ ok: true, activity: activity.rows[0] });
-  } catch (err) {
-    next(err);
-  }
-});
-
-app.patch('/jobs/:id', async (req, res, next) => {
-  try {
-    const { id } = req.params;
-    const { status, in_hands_date } = req.body || {};
-    const sets = [];
-    const values = [];
-    let i = 1;
-    if (status) {
-      sets.push(`status=$${i++}`);
-      values.push(status);
-    }
-    if (in_hands_date) {
-      sets.push(`in_hands_date=$${i++}`);
-      values.push(in_hands_date);
-    }
-    if (!sets.length) {
-      return res.status(400).json({ error: 'no changes' });
-    }
-    values.push(id);
-    const { rows } = await pool.query(
-      `UPDATE jobs SET ${sets.join(', ')} WHERE id=$${i} RETURNING *`,
-      values,
-    );
-    res.json(rows[0]);
-  } catch (err) {
-    next(err);
-  }
-});
-
-app.use((err, req, res, next) => {
-  console.error(err);
-  res.status(500).json({ error: 'Internal Server Error' });
+const app = createApp({
+  pool,
+  apiKey: process.env.API_KEY,
 });
 
 const port = process.env.PORT || 8787;

--- a/api/test/activities.ingest.test.js
+++ b/api/test/activities.ingest.test.js
@@ -1,0 +1,60 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { fileURLToPath } from 'node:url';
+import fs from 'node:fs';
+import path from 'node:path';
+import { newDb } from 'pg-mem';
+import request from 'supertest';
+import { createApp } from '../src/app.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const schemaSql = fs.readFileSync(path.resolve(__dirname, '../../db/schema.sql'), 'utf8');
+
+function createTestApp() {
+  const db = newDb({ autoCreateForeignKeyIndices: true });
+  db.public.none(schemaSql);
+  const { Pool } = db.adapters.createPg();
+  const pool = new Pool();
+  const app = createApp({ pool, apiKey: 'test-key' });
+  return { app, pool };
+}
+
+test('concurrent ingest requests reuse the same job row', async (t) => {
+  const { app, pool } = createTestApp();
+  t.after(async () => {
+    await pool.end();
+  });
+
+  const agent = request(app);
+  const payloads = [
+    { job_no: 'J12345', subject: 'Quote [J:12345] Request', snippet: 'First email', gmail_link: 'https://mail/1' },
+    { job_no: 'J12345', subject: 'Re: Quote [J:12345] Request', snippet: 'Follow up', gmail_link: 'https://mail/2' },
+  ];
+
+  const responses = await Promise.all(
+    payloads.map((body) =>
+      agent.post('/activities/ingest').set('x-api-key', 'test-key').send(body),
+    ),
+  );
+
+  for (const res of responses) {
+    assert.equal(res.status, 200);
+    assert.equal(res.body.ok, true);
+    assert.ok(res.body.activity?.id, 'activity should be returned');
+  }
+
+  const jobs = await pool.query('SELECT id, job_no, title FROM jobs');
+  assert.equal(jobs.rowCount, 1);
+  assert.equal(jobs.rows[0].job_no, 'J12345');
+  assert.equal(jobs.rows[0].title, 'Quote Request');
+
+  const activities = await pool.query('SELECT job_id, snippet FROM activities ORDER BY id');
+  assert.equal(activities.rowCount, 2);
+  assert.equal(activities.rows[0].job_id, jobs.rows[0].id);
+  assert.equal(activities.rows[1].job_id, jobs.rows[0].id);
+  assert.deepEqual(
+    activities.rows.map((row) => row.snippet),
+    payloads.map((payload) => payload.snippet),
+  );
+});


### PR DESCRIPTION
## Summary
- refactor the Express server into a reusable `createApp` factory so routes share a single pool instance
- update `/activities/ingest` to upsert jobs with `ON CONFLICT` and reuse the resulting job id when creating activities
- add a regression test using `pg-mem` and `supertest` to ensure two concurrent ingest requests for the same job number both succeed

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68cd592e49e0832eb26857842e5f66f6