### PR TITLE
Fix GitHub Pages base path for Vite build

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Vite + React</title>
+    <title>Own Ops CRM</title>
   </head>
   <body>
     <div id="root"></div>

--- a/web/vite.config.js
+++ b/web/vite.config.js
@@ -1,7 +1,10 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 
+const repoBase = '/Honors/'
+
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
+  base: process.env.NODE_ENV === 'production' ? repoBase : '/',
 })


### PR DESCRIPTION
## Summary
- configure the Vite build to use the Honors repository base path in production so assets load correctly on GitHub Pages
- update the document title to reference Own Ops CRM instead of the default Vite text

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68cd5d12b4b0832e925a8677eedcd6e6