### PR TITLE
Add GitHub Pages SPA fallback

### DIFF
--- a/web/README.md
+++ b/web/README.md
@@ -41,3 +41,5 @@ npm run build
 ```
 
 The static output under `dist/` can be published to GitHub Pages. Ensure the Supabase environment variables are configured in the Pages workflow before deploying.
+
+GitHub Pages needs a fallback page so route refreshes keep working on `https://mcnish12.github.io/Honors/`. The repo includes `public/404.html`, which implements the [spa-github-pages](https://github.com/rafrex/spa-github-pages) redirect with `pathSegmentsToKeep = 1`. Vite copies this file to `dist/404.html` during `npm run build`, so deploy both `index.html` and `404.html` together.

--- a/web/index.html
+++ b/web/index.html
@@ -4,6 +4,22 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <script>
+      ;(function (l) {
+        if (l.search[1] === '/') {
+          const decoded = l.search
+            .slice(1)
+            .split('&')
+            .map((s) => s.replace(/~and~/g, '&'))
+            .join('?')
+          window.history.replaceState(
+            null,
+            null,
+            l.pathname.slice(0, -1) + decoded + l.hash,
+          )
+        }
+      })(window.location)
+    </script>
     <title>Own Ops CRM</title>
   </head>
   <body>

--- a/web/public/404.html
+++ b/web/public/404.html
@@ -1,0 +1,28 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Redirecting…</title>
+    <script>
+      const pathSegmentsToKeep = 1
+      const l = window.location
+      const origin =
+        l.protocol + '//' + l.hostname + (l.port ? ':' + l.port : '')
+      const basePath = l.pathname
+        .split('/')
+        .slice(0, 1 + pathSegmentsToKeep)
+        .join('/')
+      const nextPath = l.pathname
+        .slice(1)
+        .split('/')
+        .slice(pathSegmentsToKeep)
+        .join('/')
+        .replace(/&/g, '~and~')
+      const search = l.search
+        ? '&' + l.search.slice(1).replace(/&/g, '~and~')
+        : ''
+      l.replace(`${origin}${basePath}/?/${nextPath}${search}${l.hash}`)
+    </script>
+  </head>
+  <body></body>
+</html>


### PR DESCRIPTION
## Summary
- add the spa-github-pages redirect script to index.html and provide a GitHub Pages-friendly 404.html fallback
- document the fallback so GitHub Pages deployments keep deep links working

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68cd960b3c8c832eae08330eb9720e3a