### PR TITLE
Allow clearing job in_hands_date via PATCH

### DIFF
--- a/api/src/app.js
+++ b/api/src/app.js
@@ -106,7 +106,8 @@ export function createApp({ pool, apiKey } = {}) {
   app.patch('/jobs/:id', async (req, res, next) => {
     try {
       const { id } = req.params;
-      const { status, in_hands_date } = req.body || {};
+      const body = req.body || {};
+      const { status, in_hands_date } = body;
       const sets = [];
       const values = [];
       let i = 1;
@@ -114,9 +115,11 @@ export function createApp({ pool, apiKey } = {}) {
         sets.push(`status=$${i++}`);
         values.push(status);
       }
-      if (in_hands_date) {
+      if (Object.prototype.hasOwnProperty.call(body, 'in_hands_date')) {
         sets.push(`in_hands_date=$${i++}`);
-        values.push(in_hands_date);
+        const normalizedInHandsDate =
+          in_hands_date === null || in_hands_date === '' ? null : in_hands_date;
+        values.push(normalizedInHandsDate);
       }
       if (!sets.length) {
         return res.status(400).json({ error: 'no changes' });

--- a/api/test/jobs.patch.test.js
+++ b/api/test/jobs.patch.test.js
@@ -1,0 +1,46 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { fileURLToPath } from 'node:url';
+import fs from 'node:fs';
+import path from 'node:path';
+import { newDb } from 'pg-mem';
+import request from 'supertest';
+import { createApp } from '../src/app.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const schemaSql = fs.readFileSync(path.resolve(__dirname, '../../db/schema.sql'), 'utf8');
+
+function createTestApp() {
+  const db = newDb({ autoCreateForeignKeyIndices: true });
+  db.public.none(schemaSql);
+  const { Pool } = db.adapters.createPg();
+  const pool = new Pool();
+  const app = createApp({ pool, apiKey: 'test-key' });
+  return { app, pool };
+}
+
+test('PATCH /jobs/:id clears in_hands_date when null', async (t) => {
+  const { app, pool } = createTestApp();
+  t.after(async () => {
+    await pool.end();
+  });
+
+  const jobResult = await pool.query(
+    'INSERT INTO jobs (job_no, title, status, in_hands_date) VALUES ($1,$2,$3,$4) RETURNING id',
+    ['J98765', 'Test Job', 'intake', '2024-01-15'],
+  );
+  const jobId = jobResult.rows[0].id;
+
+  const res = await request(app)
+    .patch(`/jobs/${jobId}`)
+    .set('x-api-key', 'test-key')
+    .send({ in_hands_date: null });
+
+  assert.equal(res.status, 200);
+  assert.equal(res.body.in_hands_date, null);
+
+  const job = await pool.query('SELECT in_hands_date FROM jobs WHERE id=$1', [jobId]);
+  assert.equal(job.rowCount, 1);
+  assert.equal(job.rows[0].in_hands_date, null);
+});


### PR DESCRIPTION
## Summary
- allow the jobs PATCH handler to detect when in_hands_date is provided and normalize empty values to null
- add an API test that confirms sending a null in_hands_date clears the value in the database

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68cd9f97d77c832ebcc0db7d22f4e962