### PR TITLE
Add display name column to app users

### DIFF
--- a/db/supabase/app_users.sql
+++ b/db/supabase/app_users.sql
@@ -7,10 +7,14 @@ create type if not exists public.user_role as enum ('admin', 'staff', 'viewer');
 create table if not exists public.app_users (
   id uuid primary key references auth.users(id) on delete cascade,
   email text not null unique,
+  display_name text,
   role public.user_role not null default 'staff',
   created_at timestamp with time zone not null default timezone('utc', now()),
   updated_at timestamp with time zone not null default timezone('utc', now())
 );
+
+alter table public.app_users
+  add column if not exists display_name text;
 
 -- 3. Automatically maintain updated_at on every change.
 create or replace function public.set_updated_at()


### PR DESCRIPTION
## Summary
- add a nullable display_name column to the app_users table definition
- include an alter table guard to backfill the column on existing deployments

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68cda803eb30832ea18ceb9c3b44635a