### PR TITLE
Add password authentication option to login page

### DIFF
--- a/web/src/App.css
+++ b/web/src/App.css
@@ -119,6 +119,12 @@ body {
   padding: 0.75rem 1rem;
 }
 
+.login-page__mode-selector {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.5rem;
+}
+
 .button {
   display: inline-flex;
   align-items: center;
@@ -143,6 +149,23 @@ body {
 .button:disabled {
   opacity: 0.6;
   cursor: not-allowed;
+}
+
+.button--subtle {
+  background: #f8f9fc;
+  color: #475467;
+  border-color: #e4e7ec;
+}
+
+.button--subtle:hover {
+  background: #eef2ff;
+  border-color: #c7d2fe;
+}
+
+.button--subtle.is-active {
+  background: #2563eb;
+  border-color: #2563eb;
+  color: #ffffff;
 }
 
 .button--ghost {

--- a/web/src/pages/Login.tsx
+++ b/web/src/pages/Login.tsx
@@ -1,15 +1,32 @@
-import { FormEvent, useState } from 'react'
+import { FormEvent, useCallback, useMemo, useState } from 'react'
 import { Navigate } from 'react-router-dom'
 import { useAuth } from '../auth/useAuth'
 
 const REDIRECT_URL = 'https://mcnish12.github.io/Honors/'
 
 export default function Login() {
-  const { status, error: authError, signInWithEmail } = useAuth()
+  const { status, error: authError, signInWithEmail, signInWithPassword } = useAuth()
+  const [mode, setMode] = useState<'magic' | 'password'>('magic')
   const [email, setEmail] = useState('')
+  const [password, setPassword] = useState('')
   const [formError, setFormError] = useState<string | null>(null)
   const [message, setMessage] = useState<string | null>(null)
   const [submitting, setSubmitting] = useState(false)
+
+  const combinedError = useMemo(() => formError || authError, [authError, formError])
+
+  const handleModeChange = useCallback(
+    (nextMode: 'magic' | 'password') => {
+      if (nextMode === mode) return
+      setMode(nextMode)
+      setFormError(null)
+      setMessage(null)
+      if (nextMode === 'magic') {
+        setPassword('')
+      }
+    },
+    [mode],
+  )
 
   if (status === 'authed') {
     return <Navigate to="/" replace />
@@ -25,19 +42,43 @@ export default function Login() {
       return
     }
 
+    if (mode === 'password' && !password) {
+      setFormError('Enter your password to continue.')
+      return
+    }
+
     setSubmitting(true)
     setFormError(null)
-    setMessage(null)
+    if (mode === 'magic') {
+      setMessage(null)
+    }
 
     try {
-      const { error } = await signInWithEmail(trimmedEmail, REDIRECT_URL)
-      if (error) {
-        setFormError(error.message || 'Unable to send the sign-in link. Please try again.')
+      if (mode === 'magic') {
+        const { error } = await signInWithEmail(trimmedEmail, REDIRECT_URL)
+        if (error) {
+          setFormError(
+            error.message || 'Unable to send the sign-in link. Please try again.',
+          )
+        } else {
+          setMessage('Check your email for a sign-in link. The message expires in 5 minutes.')
+        }
       } else {
-        setMessage('Check your email for a sign-in link. The message expires in 5 minutes.')
+        const { error } = await signInWithPassword(trimmedEmail, password)
+        if (error) {
+          setFormError(
+            error.message ||
+              'Unable to sign in with that email and password. Please try again.',
+          )
+        }
       }
     } catch (err) {
-      const friendly = err instanceof Error ? err.message : 'Unable to send the sign-in link.'
+      const friendly =
+        err instanceof Error
+          ? err.message
+          : mode === 'magic'
+            ? 'Unable to send the sign-in link.'
+            : 'Unable to sign in with the provided credentials.'
       setFormError(friendly)
     }
 
@@ -48,7 +89,31 @@ export default function Login() {
     <div className="page login-page">
       <div className="card">
         <h1>Sign in to Honors</h1>
-        <p className="card__subtitle">Enter your work email to receive a secure magic link.</p>
+        <p className="card__subtitle">
+          Use a magic link or enter your password to securely access your account.
+        </p>
+        <div className="login-page__mode-selector" role="tablist" aria-label="Sign-in method">
+          <button
+            type="button"
+            role="tab"
+            aria-selected={mode === 'magic'}
+            className={`button button--subtle${mode === 'magic' ? ' is-active' : ''}`}
+            onClick={() => handleModeChange('magic')}
+            disabled={submitting}
+          >
+            Magic link
+          </button>
+          <button
+            type="button"
+            role="tab"
+            aria-selected={mode === 'password'}
+            className={`button button--subtle${mode === 'password' ? ' is-active' : ''}`}
+            onClick={() => handleModeChange('password')}
+            disabled={submitting}
+          >
+            Email &amp; password
+          </button>
+        </div>
         <form className="form" onSubmit={handleSubmit}>
           <label className="form__field">
             <span>Email address</span>
@@ -62,14 +127,34 @@ export default function Login() {
               required
             />
           </label>
-          {(formError || authError) && (
+          {mode === 'password' && (
+            <label className="form__field">
+              <span>Password</span>
+              <input
+                type="password"
+                name="current-password"
+                autoComplete="current-password"
+                value={password}
+                onChange={(event) => setPassword(event.target.value)}
+                disabled={submitting}
+                required
+              />
+            </label>
+          )}
+          {combinedError && (
             <p className="form__error" role="alert">
-              {formError || authError}
+              {combinedError}
             </p>
           )}
-          {message && <p className="form__status">{message}</p>}
+          {mode === 'magic' && message && <p className="form__status">{message}</p>}
           <button type="submit" className="button" disabled={submitting}>
-            {submitting ? 'Sending link…' : 'Send magic link'}
+            {submitting
+              ? mode === 'magic'
+                ? 'Sending link…'
+                : 'Signing in…'
+              : mode === 'magic'
+                ? 'Send magic link'
+                : 'Sign in'}
           </button>
         </form>
         <p className="card__footer">Need help? Contact an administrator to verify your access.</p>


### PR DESCRIPTION
## Summary
- add a password-based sign-in helper to the auth context alongside the existing email flow
- redesign the login page to support magic link and password tabs with context-aware messaging
- introduce supporting styles for the new sign-in mode selector and toggle buttons

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_b_68cdadd8c454832eb035d98fef722bc6