### PR TITLE
Handle duplicate user_role enum recreation safely

### DIFF
--- a/db/supabase/app_users.sql
+++ b/db/supabase/app_users.sql
@@ -1,7 +1,13 @@
 -- Supabase SQL for Honors Ops Auth & Roles
 -- Run this script in the Supabase SQL editor after creating your project.
 
-create type if not exists public.user_role as enum ('admin', 'staff', 'viewer');
+do $$
+begin
+  create type public.user_role as enum ('admin', 'staff', 'viewer');
+exception
+  when duplicate_object then null;
+end;
+$$;
 
 -- 2. Create the app_users table keyed by the auth user id.
 create table if not exists public.app_users (


### PR DESCRIPTION
## Summary
- wrap the `public.user_role` enum creation in a DO block so rerunning the script ignores duplicate_object errors

## Testing
- sudo -u postgres psql -f db/supabase/app_users.sql

------
https://chatgpt.com/codex/tasks/task_b_68cdc5af4c80832ebc34d1bf14124990